### PR TITLE
Per-task aspect schema & layout querying

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ computational task output as follows:
 `<task-name>` should be replaced by any available task name listed under
 `/algorithms/` endpoint.
 
+You may also query for single aspect instead of complete list, providing its name:
+`/schema/outputs/<task-name>/<aspect-name>`.
+
 Expected HTTP return code is `200`. If task of the given name does not exist,
 return code is `404`. Supported HTTP method is `GET`.
 
@@ -163,6 +166,9 @@ computational task output narrowing form layout as follows:
     ...
 ]
 ```
+
+You may also query for single aspect instead of complete list,
+similarly as for `/schema` endpoint: `/layout/outputs/<task-name>/<aspect-name>`.
 
 Expected HTTP return code is `200`. If task of the given name does not exist,
 return code is `404`. Supported HTTP method is `GET`.

--- a/api.py
+++ b/api.py
@@ -27,18 +27,18 @@ NOT_FOUND = "", 404
 Response = Tuple[str, int]
 
 
-def _proxy(request) -> Response:
+def _jsonify(response) -> Response:
     """Pass request data as a response"""
-    return flask.jsonify(request.json()), request.status_code
+    return flask.jsonify(response.json()), response.status_code
 
 
-def _ask_for(task: str, endpoint: str, protocol: str="http") -> Response:
+def _proxy(task: str, endpoint: str, protocol: str="http", method=requests.get, *args, **kwargs) -> Response:
     try:
-        backend = protocol + "://" + discover.backend(task)
+        worker_url = protocol + "://" + discover.backend(task)
     except KeyError:
         return NOT_FOUND
-    request = requests.get(backend + endpoint + task)
-    return _proxy(request)
+    request = method(worker_url + endpoint, *args, **kwargs)
+    return _jsonify(request)
 
 
 @app.route('/schema/inputs/<string:task_name>/')
@@ -48,7 +48,7 @@ def get_inputs(task_name: str) -> Response:
     Returns:
         Normalized worker inputs definition.
     """
-    return _ask_for(task_name, "/schema/inputs/")
+    return _proxy(task_name, "/schema/inputs/{task_name}".format(task_name=task_name))
 
 
 @app.route('/schema/outputs/<string:task_name>/')
@@ -58,7 +58,7 @@ def get_outputs(task_name: str) -> Response:
     Returns:
         Normalized output query patterns definition.
     """
-    return _ask_for(task_name, "/schema/outputs/")
+    return _proxy(task_name, "/schema/outputs/{task_name}".format(task_name=task_name))
 
 
 @app.route('/schema/outputs/<string:task_name>/<string:aspect_name>')
@@ -68,8 +68,8 @@ def get_output_by_aspect(task_name: str, aspect_name: str) -> Response:
     Returns:
         Normalized output query pattern definition.
     """
-    return _ask_for(task_name, "/schema/outputs/{task_name}/{aspect_name}".format(task_name=task_name,
-                                                                                  aspect_name=aspect_name))
+    return _proxy(task_name, "/schema/outputs/{task_name}/{aspect_name}".format(task_name=task_name,
+                                                                                aspect_name=aspect_name))
 
 
 @app.route('/layout/inputs/<string:task_name>/')
@@ -79,7 +79,7 @@ def get_inputs_layout(task_name: str) -> Response:
     Returns:
         Definition of input form.
     """
-    return _ask_for(task_name, "/layout/inputs/")
+    return _proxy(task_name, "/layout/inputs/{task_name}".format(task_name=task_name))
 
 
 @app.route('/layout/outputs/<string:task_name>/')
@@ -89,7 +89,7 @@ def get_outputs_layout(task_name: str) -> Response:
     Returns:
         Definitions of forms for narrowing down the result scope.
     """
-    return _ask_for(task_name, "/layout/outputs/")
+    return _proxy(task_name, "/layout/outputs/{task_name}".format(task_name=task_name))
 
 
 @app.route('/layout/outputs/<string:task_name>/<string:aspect_name>')
@@ -99,8 +99,8 @@ def get_output_layout_by_aspect(task_name: str, aspect_name: str) -> Response:
     Returns:
         Definition of form for narrowing down the result scope.
     """
-    return _ask_for(task_name, "/layout/outputs/{task_name}/{aspect_name}".format(task_name=task_name,
-                                                                                  aspect_name=aspect_name))
+    return _proxy(task_name, "/layout/outputs/{task_name}/{aspect_name}".format(task_name=task_name,
+                                                                                aspect_name=aspect_name))
 
 
 @app.route('/results/')
@@ -109,8 +109,8 @@ def list_analyses():
     return flask.jsonify(discover.finished_analyses()), 200
 
 
-@app.route('/results/<string:task_name>/<string:task_id>/<string:aspect>/', methods=['POST'])
-def get_result(task_name: str, task_id: str, aspect: str):
+@app.route('/results/<string:task_name>/<string:task_id>/<string:aspect_name>/', methods=['POST'])
+def get_result(task_name: str, task_id: str, aspect_name: str):
     """Get result of algorithm run from its backend.
 
     Query is parsed from JSON sent with the POST request.
@@ -118,14 +118,9 @@ def get_result(task_name: str, task_id: str, aspect: str):
     Returns:
         Normalized algorithms result.
     """
-    try:
-        backend = "http://" + discover.backend(task_name)
-    except KeyError:
-        return NOT_FOUND
-    url = backend + "/results/" + task_name + "/" + task_id + "/" + aspect
-    json = flask.request.get_json()
-    request = requests.post(url, json=json)
-    return _proxy(request)
+    return _proxy(task_name, "/results/{task_name}/{task_id}/{aspect_name}"
+                             .format(task_name=task_name, task_id=task_id, aspect_name=aspect_name),
+                  method=requests.post, json=flask.request.get_json())
 
 
 @app.route('/schedule/<string:task_name>/', methods=['POST'])

--- a/api.py
+++ b/api.py
@@ -61,6 +61,17 @@ def get_outputs(task_name: str) -> Response:
     return _ask_for(task_name, "/schema/outputs/")
 
 
+@app.route('/schema/outputs/<string:task_name>/<string:aspect_name>')
+def get_output_by_aspect(task_name: str, aspect_name: str) -> Response:
+    """Get specific aspect's output query pattern from algorithm backend
+
+    Returns:
+        Normalized output query pattern definition.
+    """
+    return _ask_for(task_name, "/schema/outputs/{task_name}/{aspect_name}".format(task_name=task_name,
+                                                                                  aspect_name=aspect_name))
+
+
 @app.route('/layout/inputs/<string:task_name>/')
 def get_inputs_layout(task_name: str) -> Response:
     """Get the definition of algorithm parameterization form
@@ -79,6 +90,17 @@ def get_outputs_layout(task_name: str) -> Response:
         Definitions of forms for narrowing down the result scope.
     """
     return _ask_for(task_name, "/layout/outputs/")
+
+
+@app.route('/layout/outputs/<string:task_name>/<string:aspect_name>')
+def get_output_layout_by_aspect(task_name: str, aspect_name: str) -> Response:
+    """Get the specific aspect's definition of result parameterization form
+
+    Returns:
+        Definition of form for narrowing down the result scope.
+    """
+    return _ask_for(task_name, "/layout/outputs/{task_name}/{aspect_name}".format(task_name=task_name,
+                                                                                  aspect_name=aspect_name))
 
 
 @app.route('/results/')


### PR DESCRIPTION
Extends existing set of worker proxy calls:

- `GET /schema/outputs/<string:task_name>/`
- `GET /layout/outputs/<string:task_name>/`

with per-aspect calls:

- `GET /schema/outputs/<string:task_name>/<string:aspect_name>`
- `GET /layout/outputs/<string:task_name>/<string:aspect_name>`